### PR TITLE
View habit details with controllers and firestore

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ExampleActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ExampleActivity.java
@@ -47,7 +47,7 @@ public class ExampleActivity extends AppCompatActivity {
             public void onClick(View v) {
                 Intent intent = new Intent(getApplicationContext(), ViewHabitActivity.class);
                 final String HABIT_ID = "HABIT_ID";
-                int habitID = 1;
+                String habitID = "IdninLJ01WM1PD8e4NzX";
                 intent.putExtra(HABIT_ID, habitID);
                 startActivity(intent);
             }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventController.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventController.java
@@ -133,12 +133,7 @@ public class HabitEventController {
                         if (task.isSuccessful()) {
                             // Append every document into habitEventDataList
                             for (QueryDocumentSnapshot doc : task.getResult()) {
-                                String id = (String) doc.getId();
-                                Date date  = ((Timestamp) doc.getData().get("date")).toDate();
-                                String location = (String) doc.getData().get("location");
-                                String comment = (String) doc.getData().get("comment");
-                                Image image = (Image) doc.getData().get("image");
-                                habitEventDataList.add(new HabitEventModel(id, location, date, comment, image, habitID));
+                                habitEventDataList.add(doc.toObject(HabitEventModel.class));
                             }
                             hbEvtLstCallback.onCallback(habitEventDataList);
                         } else {

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventController.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventController.java
@@ -1,5 +1,6 @@
 package com.cmput301f21t09.budgetprojectname;
 
+import android.media.Image;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -8,9 +9,16 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+import java.util.Date;
 
 /**
  * Represents a Habit Event Controller that interfaces with FirestoreDB to
@@ -38,6 +46,10 @@ public class HabitEventController {
 
     public interface HabitEventIDCallback{
         void onCallback(String habitEventID);
+    }
+
+    public interface HabitEventListCallback {
+        void onCallback(ArrayList<HabitEventModel> habitEventList);
     }
 
     /**
@@ -99,6 +111,39 @@ public class HabitEventController {
      * notifyListeners()
      * commit()
      */
-    // TODO: add read scenario
+
+    /**
+     * Read habitEvent document in the habit_events collection
+     *
+     * @param habitID habitID is used to query all the corresponding habit events
+     */
+    public void readHabitEvent(String habitID, HabitEventListCallback hbEvtLstCallback) {
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        ArrayList<HabitEventModel> habitEventDataList = new ArrayList<>();
+        CollectionReference collectionReference = db.collection("habit_events");
+        collectionReference
+                .whereEqualTo("habitID", habitID)
+                .get()
+                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                    @Override
+                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                        if (task.isSuccessful()) {
+                            // Append every document into habitEventDataList
+                            for (QueryDocumentSnapshot doc : task.getResult()) {
+                                String id = (String) doc.getId();
+                                Date date  = ((Timestamp) doc.getData().get("date")).toDate();
+                                String location = (String) doc.getData().get("location");
+                                String comment = (String) doc.getData().get("comment");
+                                Image image = (Image) doc.getData().get("image");
+                                habitEventDataList.add(new HabitEventModel(id, location, date, comment, image, habitID));
+                            }
+                            hbEvtLstCallback.onCallback(habitEventDataList);
+                        } else {
+                            Log.d(TAG, "Error: ", task.getException());
+                        }
+                    }
+                });
+    }
+
     // TODO: add delete scenario
 }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventController.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventController.java
@@ -48,6 +48,9 @@ public class HabitEventController {
         void onCallback(String habitEventID);
     }
 
+    /**
+     * HabitEventListCallback interface
+     */
     public interface HabitEventListCallback {
         void onCallback(ArrayList<HabitEventModel> habitEventList);
     }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventCustomList.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventCustomList.java
@@ -1,5 +1,7 @@
 package com.cmput301f21t09.budgetprojectname;
 
+import static java.util.Objects.isNull;
+
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,16 +13,23 @@ import androidx.annotation.Nullable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 
+/**
+ * CustomList for ViewHabitActivity
+ * Show the habit event's date and whether or not the user has added a location, comment, and/or photograph
+ */
 public class HabitEventCustomList extends ArrayAdapter<HabitEventModel> {
-    private ArrayList<HabitEventModel> habits;
+    private ArrayList<HabitEventModel> habitEvents;
     private Context context;
 
-
-    public HabitEventCustomList(Context context, ArrayList<HabitEventModel> habits) {
-        super(context, 0, habits);
-        this.habits = habits;
+    /**
+     * Constructor for HabitEventCustomList
+     * @param context
+     * @param habitEvents
+     */
+    public HabitEventCustomList(Context context, ArrayList<HabitEventModel> habitEvents) {
+        super(context, 0, habitEvents);
+        this.habitEvents = habitEvents;
         this.context = context;
     }
 
@@ -30,19 +39,50 @@ public class HabitEventCustomList extends ArrayAdapter<HabitEventModel> {
             view = LayoutInflater.from(context).inflate(R.layout.activity_view_habit_event_custom_list, parent, false);
         }
 
+        HabitEventModel habitEvent = habitEvents.get(position);
+
+        /* Views */
+
+        /**
+         * Text View for habit date
+         */
         TextView habitDate = view.findViewById(R.id.date);
+
+        /**
+         * Image View for location icon
+         */
         ImageView locationIcon = view.findViewById(R.id.location_icon);
+
+        /**
+         * Image View for description icon
+         */
         ImageView descriptionIcon = view.findViewById(R.id.comment_icon);
+
+        /**
+         * Image View for Image icon
+         */
         ImageView ImageIcon = view.findViewById(R.id.image_icon);
 
-        // Todo: Change the date of past habit events to actual habit event data from Firestore
+        // Set the date when the habit event occured
         DateFormat df = new SimpleDateFormat("MMMM dd, YYYY");
-        habitDate.setText(df.format(new Date()));
+        habitDate.setText(df.format(habitEvent.getDate()));
 
-        // Todo: Change the icons' opacity according to the actual habit events' data from Firestore
-        locationIcon.setImageResource(R.drawable.ic_map_marker_positive);
-        descriptionIcon.setImageResource(R.drawable.ic_comment_negative);
-        ImageIcon.setImageResource(R.drawable.ic_image_positive);
+        // Set the location, comment, and image icons accordingly
+        if (isNull(habitEvent.getLocation())) {
+            locationIcon.setImageResource(R.drawable.ic_map_marker_negative);
+        } else {
+            locationIcon.setImageResource(R.drawable.ic_map_marker_positive);
+        }
+        if (isNull(habitEvent.getComment())) {
+            descriptionIcon.setImageResource(R.drawable.ic_comment_negative);
+        } else {
+            descriptionIcon.setImageResource(R.drawable.ic_comment_positive);
+        }
+        if (isNull(habitEvent.getImage())) {
+            ImageIcon.setImageResource(R.drawable.ic_image_negative);
+        } else {
+            ImageIcon.setImageResource(R.drawable.ic_image_positive);
+        }
 
         return view;
     }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventCustomList.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventCustomList.java
@@ -1,6 +1,6 @@
 package com.cmput301f21t09.budgetprojectname;
 
-import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import android.content.Context;
 import android.view.LayoutInflater;
@@ -68,19 +68,15 @@ public class HabitEventCustomList extends ArrayAdapter<HabitEventModel> {
         habitDate.setText(df.format(habitEvent.getDate()));
 
         // Set the location, comment, and image icons accordingly
-        if (isNull(habitEvent.getLocation())) {
-            locationIcon.setImageResource(R.drawable.ic_map_marker_negative);
-        } else {
+        // location and comment are empty string by default
+        // image is null by default
+        if (habitEvent.getLocation().length() > 0) {
             locationIcon.setImageResource(R.drawable.ic_map_marker_positive);
         }
-        if (isNull(habitEvent.getComment())) {
-            descriptionIcon.setImageResource(R.drawable.ic_comment_negative);
-        } else {
+        if (habitEvent.getComment().length() > 0) {
             descriptionIcon.setImageResource(R.drawable.ic_comment_positive);
         }
-        if (isNull(habitEvent.getImage())) {
-            ImageIcon.setImageResource(R.drawable.ic_image_negative);
-        } else {
+        if (nonNull(habitEvent.getImage())) {
             ImageIcon.setImageResource(R.drawable.ic_image_positive);
         }
 

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventModel.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/HabitEventModel.java
@@ -6,6 +6,8 @@ import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.google.firebase.firestore.DocumentId;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -17,6 +19,7 @@ public class HabitEventModel{
     /**
      * HabitEvent ID
      */
+    @DocumentId
     private String ID;
 
     /**

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
@@ -12,13 +12,61 @@ import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.cmput301f21t09.budgetprojectname.controllers.HabitController;
+import com.cmput301f21t09.budgetprojectname.models.IHabitModel;
+import com.cmput301f21t09.budgetprojectname.models.IWeeklyHabitScheduleModel;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 
 public class ViewHabitActivity extends AppCompatActivity {
-    private TextView habitName;
+
+    /* Controllers */
+    
+    private HabitController controller;
+
+    /**
+     * Controller for fetching habit events
+     */
+    private HabitEventController habitEventController = new HabitEventController();
+
+    /* Views */
+
+    /**
+     * TextView for displaying title of habit on Toolbar
+     */
+    private TextView habitTitleToolbar;
+
+    /**
+     * Text View for displaying habit title
+     */
+    private TextView habitTitle;
+
+
+    /**
+     * Text View for displaying habit Description
+     */
+    private TextView habitDescription;
+
+    /**
+     * Text View for displaying habit Date
+     */
+    private TextView habitDate;
+
+    // Image View for each of the icon
+    private ImageView sundayIcon;
+    private ImageView mondayIcon;
+    private ImageView tuesdayIcon;
+    private ImageView wednesdayIcon;
+    private ImageView thursdayIcon;
+    private ImageView fridayIcon;
+    private ImageView saturdayIcon;
+
+    /**
+     * List View for habit events
+     */
     private ListView habitEventList;
+
     ArrayAdapter<HabitEventModel> habitEventAdapter;
     ArrayList<HabitEventModel> habitEventDataList;
 
@@ -27,64 +75,42 @@ public class ViewHabitActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_view_habit_screen);
 
-        // The specific habitID is fetched from the previous activity
+        // Get the habitID from the previous activity
         Intent intent = getIntent();
-        int habitID = intent.getIntExtra("HABIT_ID", -1);
+        String habitID = intent.getStringExtra("HABIT_ID");
 
-        final TextView habitTitle = (TextView) findViewById(R.id.habitTitle);
-        final TextView habitDescription = (TextView) findViewById(R.id.habitDescription);
-        final TextView habitDate = (TextView) findViewById(R.id.habitDate);
+        /* Habit Details */
 
-        // Todo: Implement edit Habit function
-        final Button editHabitBtn = findViewById(R.id.editHabitButton);
-        editHabitBtn.setOnClickListener(new View.OnClickListener() {
-            public void onClick(View v) {
-            }
-        });
+        // Retrieve the specific views
+        habitTitle = (TextView) findViewById(R.id.habitTitle);
+        habitDescription = (TextView) findViewById(R.id.habitDescription);
+        habitDate = (TextView) findViewById(R.id.habitDate);
+        habitTitleToolbar = findViewById(R.id.toolbar_title);
+        // Set up the controller and set the views accordingly
+        controller = HabitController.getEditHabitController(habitID);
+        controller.attachListener(this::updateView);
+        updateView();
 
-        // Todo: Change the habit title and description to actual data from Firestore using habitID
-        habitTitle.setText("Wash Dishes");
-        habitDescription.setText("Dirty dishes really suck :(");
+        /* Past Habit Events */
 
-        // Todo: Change the frequency of habit to actual data from Firestore using habitID
-        ImageView sundayIcon = findViewById(R.id.sunday_icon);
-        ImageView mondayIcon = findViewById(R.id.monday_icon);
-        ImageView tuesdayIcon = findViewById(R.id.tuesday_icon);
-        ImageView wednesdayIcon = findViewById(R.id.wednesday_icon);
-        ImageView thursdayIcon = findViewById(R.id.thursday_icon);
-        ImageView fridayIcon = findViewById(R.id.friday_icon);
-        ImageView saturdayIcon = findViewById(R.id.saturday_icon);
-
-        // If a user chooses to commit to the habit on a particular day, the "ic_<Day>_positive" icon
-        // will be shown. Similarly, the <Day>negative icon will be shown if the user chooses not to commit
-        sundayIcon.setImageResource(R.drawable.ic_sunday_negative);
-        mondayIcon.setImageResource(R.drawable.ic_monday_positive);
-        tuesdayIcon.setImageResource(R.drawable.ic_tuesday_positive);
-        wednesdayIcon.setImageResource(R.drawable.ic_wednesday_positive);
-        thursdayIcon.setImageResource(R.drawable.ic_thursday_negative);
-        fridayIcon.setImageResource(R.drawable.ic_friday_negative);
-        saturdayIcon.setImageResource(R.drawable.ic_saturday_negative);
-
-        // Todo: Change the habit date to the actual date from Firestore using habitID
-        habitDate.setText(new SimpleDateFormat("MM/dd/yyyy").format(new Date()));
-
-        // The code below deals with the past habit events. The HabitEventCustomList is used
-        // to arrange and output the details
-        // Todo: Change the past habit events' data below to actual data from Firestore using HabitID and HabitEventID
-
-        String[] locations = {"", "", "", "", "", "", "", "", "", "", "", ""};
-        Date[] dates = {new Date(), new Date(), new Date(), new Date(), new Date(), new Date(), new Date(), new Date(), new Date(), new Date(), new Date(), new Date()};
-        String[] descriptions = {"", "", "", "", "", "", "", "", "", "", "", ""};
-
+        // Retrieve the specific view
         habitEventList = findViewById(R.id.past_habit_event_list);
+
+        // Set up the list and send an empty list to the view
         habitEventDataList = new ArrayList<>();
-
-        for (int i = 0; i < locations.length; i++) {
-            habitEventDataList.add(new HabitEventModel());
-        }
-
         habitEventAdapter = new HabitEventCustomList(this, habitEventDataList);
         habitEventList.setAdapter(habitEventAdapter);
+
+        // Fetches the past habit events related to the current habit from Firestore using habitID
+        // and update the view
+        habitEventController.readHabitEvent(habitID, new HabitEventController.HabitEventListCallback() {
+            @Override
+            public void onCallback(ArrayList<HabitEventModel> hbEvtLst) {
+                habitEventDataList.clear();
+                habitEventDataList.addAll(hbEvtLst);
+                habitEventAdapter.notifyDataSetChanged();
+            }
+        });
 
         // Go Back
         ImageButton back = findViewById(R.id.view_habit_back_button);
@@ -92,10 +118,81 @@ public class ViewHabitActivity extends AppCompatActivity {
             finish();
         });
 
+        // Edit habit
+        // Todo: Implement edit Habit function
+        final Button editHabitBtn = findViewById(R.id.editHabitButton);
+        editHabitBtn.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+            }
+        });
+
         // Delete Habit
         ImageButton remove = findViewById(R.id.view_habit_remove_button);
         remove.setOnClickListener(v -> {
             // TODO: Remove Targeted Habit. Dialog To Confirm?
         });
+    }
+
+    /**
+     * Update the views of the habit details
+     */
+    private void updateView() {
+        /**
+         * Get the image views
+         */
+        sundayIcon = findViewById(R.id.sunday_icon);
+        mondayIcon = findViewById(R.id.monday_icon);
+        tuesdayIcon = findViewById(R.id.tuesday_icon);
+        wednesdayIcon = findViewById(R.id.wednesday_icon);
+        thursdayIcon = findViewById(R.id.thursday_icon);
+        fridayIcon = findViewById(R.id.friday_icon);
+        saturdayIcon = findViewById(R.id.saturday_icon);
+
+        // TODO: maybe refactor methods like these to attach to specific "streams" of updated data?
+        if(controller.isTaskComplete(HabitController.HABIT_MODEL_LOAD)){
+            // Set the toolbar title, habit tile, habit reason, and habit date view
+            IHabitModel model = controller.getModel();
+            habitTitleToolbar.setText(model.getTitle());
+            habitTitle.setText(model.getTitle());
+            habitDescription.setText(model.getReason());
+            habitDate.setText(new SimpleDateFormat("MM/dd/yyyy").format(model.getStartDate()));
+
+            // Set the frequency of habit accordingly
+            IWeeklyHabitScheduleModel schedule = (IWeeklyHabitScheduleModel) model.getSchedule();
+            if (schedule.getDay(IWeeklyHabitScheduleModel.SUNDAY))
+                sundayIcon.setImageResource(R.drawable.ic_sunday_positive);
+            else
+                sundayIcon.setImageResource(R.drawable.ic_sunday_negative);
+
+            if (schedule.getDay(IWeeklyHabitScheduleModel.MONDAY))
+                mondayIcon.setImageResource(R.drawable.ic_monday_positive);
+            else
+                mondayIcon.setImageResource(R.drawable.ic_monday_negative);
+
+            if (schedule.getDay(IWeeklyHabitScheduleModel.TUESDAY))
+                tuesdayIcon.setImageResource(R.drawable.ic_tuesday_positive);
+            else
+                tuesdayIcon.setImageResource(R.drawable.ic_tuesday_negative);
+
+            if (schedule.getDay(IWeeklyHabitScheduleModel.WEDNESDAY))
+                wednesdayIcon.setImageResource(R.drawable.ic_wednesday_positive);
+            else
+                wednesdayIcon.setImageResource(R.drawable.ic_wednesday_negative);
+
+            if (schedule.getDay(IWeeklyHabitScheduleModel.THURSDAY))
+                thursdayIcon.setImageResource(R.drawable.ic_thursday_positive);
+            else
+                thursdayIcon.setImageResource(R.drawable.ic_thursday_negative);
+
+            if (schedule.getDay(IWeeklyHabitScheduleModel.FRIDAY))
+                fridayIcon.setImageResource(R.drawable.ic_friday_positive);
+            else
+                fridayIcon.setImageResource(R.drawable.ic_friday_negative);
+
+            if (schedule.getDay(IWeeklyHabitScheduleModel.SATURDAY))
+                saturdayIcon.setImageResource(R.drawable.ic_saturday_positive);
+            else
+                saturdayIcon.setImageResource(R.drawable.ic_saturday_negative);
+        }
     }
 }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
@@ -165,38 +165,24 @@ public class ViewHabitActivity extends AppCompatActivity {
             IWeeklyHabitScheduleModel schedule = (IWeeklyHabitScheduleModel) model.getSchedule();
             if (schedule.getDay(IWeeklyHabitScheduleModel.SUNDAY))
                 sundayIcon.setImageResource(R.drawable.ic_sunday_positive);
-            else
-                sundayIcon.setImageResource(R.drawable.ic_sunday_negative);
 
             if (schedule.getDay(IWeeklyHabitScheduleModel.MONDAY))
                 mondayIcon.setImageResource(R.drawable.ic_monday_positive);
-            else
-                mondayIcon.setImageResource(R.drawable.ic_monday_negative);
 
             if (schedule.getDay(IWeeklyHabitScheduleModel.TUESDAY))
                 tuesdayIcon.setImageResource(R.drawable.ic_tuesday_positive);
-            else
-                tuesdayIcon.setImageResource(R.drawable.ic_tuesday_negative);
 
             if (schedule.getDay(IWeeklyHabitScheduleModel.WEDNESDAY))
                 wednesdayIcon.setImageResource(R.drawable.ic_wednesday_positive);
-            else
-                wednesdayIcon.setImageResource(R.drawable.ic_wednesday_negative);
 
             if (schedule.getDay(IWeeklyHabitScheduleModel.THURSDAY))
                 thursdayIcon.setImageResource(R.drawable.ic_thursday_positive);
-            else
-                thursdayIcon.setImageResource(R.drawable.ic_thursday_negative);
 
             if (schedule.getDay(IWeeklyHabitScheduleModel.FRIDAY))
                 fridayIcon.setImageResource(R.drawable.ic_friday_positive);
-            else
-                fridayIcon.setImageResource(R.drawable.ic_friday_negative);
 
             if (schedule.getDay(IWeeklyHabitScheduleModel.SATURDAY))
                 saturdayIcon.setImageResource(R.drawable.ic_saturday_positive);
-            else
-                saturdayIcon.setImageResource(R.drawable.ic_saturday_negative);
         }
     }
 }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
@@ -89,6 +89,7 @@ public class ViewHabitActivity extends AppCompatActivity {
         habitDescription = (TextView) findViewById(R.id.habitDescription);
         habitDate = (TextView) findViewById(R.id.habitDate);
         habitTitleToolbar = findViewById(R.id.toolbar_title);
+        
         // Set up the controller and set the views accordingly
         controller = HabitController.getEditHabitController(habitID);
         controller.attachListener(this::updateView);
@@ -151,7 +152,7 @@ public class ViewHabitActivity extends AppCompatActivity {
         fridayIcon = findViewById(R.id.friday_icon);
         saturdayIcon = findViewById(R.id.saturday_icon);
 
-        // TODO: maybe refactor methods like these to attach to specific "streams" of updated data?
+        // Set the views of the habit details accordingly
         if(controller.isTaskComplete(HabitController.HABIT_MODEL_LOAD)){
             // Set the toolbar title, habit tile, habit reason, and habit date view
             IHabitModel model = controller.getModel();

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
@@ -22,7 +22,10 @@ import java.util.ArrayList;
 public class ViewHabitActivity extends AppCompatActivity {
 
     /* Controllers */
-    
+
+    /**
+     * Controller for fetching habit details
+     */
     private HabitController controller;
 
     /**

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitActivity.java
@@ -89,7 +89,7 @@ public class ViewHabitActivity extends AppCompatActivity {
         habitDescription = (TextView) findViewById(R.id.habitDescription);
         habitDate = (TextView) findViewById(R.id.habitDate);
         habitTitleToolbar = findViewById(R.id.toolbar_title);
-        
+
         // Set up the controller and set the views accordingly
         controller = HabitController.getEditHabitController(habitID);
         controller.attachListener(this::updateView);


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
Note: I've added a `@DocumentId` annotation for the habit event id in `HabitEventModel.java`. The reason for this is for deserialization when converting a habit event document to a `HabitEventModel` object as in `habitEventDataList.add(doc.toObject(HabitEventModel.class));`
https://firebase.google.com/docs/reference/android/com/google/firebase/firestore/DocumentId

Implemented the functions necessary to fetch habit details and past habit events from firestore.
Mock data in the activity is no longer used. Instead, a habit ID is passed into the activity through intent. 

For the Habit Details
- Habit title is shown
- Habit reason is shown
- Habit start date is shown
- Frequency of habit is shown

For the Past habit events:
- Each habit event associated with the habit is shown 
- The three icons reflect whether the user has (added a photo, comment, and image)

Note: Tests are yet to be written. 

<!-- Provide a list of changes here -->
![lastest_view](https://user-images.githubusercontent.com/37930535/140296675-7366479e-d1ac-4daf-a396-256701b29ed9.gif)

## Screenshots

<!-- Prefer an animated gif -->

## Checklist

- [ ] Automated tests
- [x] Screenshots included (if necessary)
- [x] Code is well commented

Closes #84 

