### PR TITLE
Improve UI transitions of Delete Habit Event

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitEventActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/ViewHabitEventActivity.java
@@ -87,6 +87,7 @@ public class ViewHabitEventActivity extends AppCompatActivity {
             Intent deleteIntent = new Intent(getApplicationContext(), ViewHabitActivity.class);
             final String HABIT_ID = "HABIT_ID";
             deleteIntent.putExtra(HABIT_ID, habitID);
+            deleteIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(deleteIntent);
         });
     }


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
Improved the UI transitions of deleting a habit event. 

Previously, the user had to click on the back button several times in order to get back to the main fragment after deleting a habit event. This minor change would bring the user back to the main fragment with a single back button tap after the user deletes a habit event. 

<!-- Provide a list of changes here -->

## Screenshots
![deleteHabitEvent](https://user-images.githubusercontent.com/37930535/142286236-aded6fd2-56b5-401a-b121-b63e3bb6d0ce.gif)


<!-- Prefer an animated gif -->

## Checklist

- [ ] Automated tests
- [x] Screenshots included (if necessary)
- [x] Code is well commented

Closes #ISSUE_ID
