### PR TITLE
Link profile to search fragment

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/models/HabitModel.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/models/HabitModel.java
@@ -147,6 +147,31 @@ public class HabitModel implements IHabitModel {
     }
 
     /**
+     * Get all the another user's habits
+     *
+     * @return load task for all user's habits
+     */
+    public static ServiceTask<List<HabitModel>> getAllForAnotherUser(String UID) {
+        ServiceTaskManager<List<HabitModel>> taskManager = new ServiceTaskManager<>();
+        FirebaseFirestore.getInstance().collection(HABIT_COLLECTION_ID)
+                .whereEqualTo("uid", UID)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        List<HabitModel> models = new ArrayList<>();
+                        HabitModelMapParser parser = new HabitModelMapParser();
+                        for (QueryDocumentSnapshot document : task.getResult()) {
+                            models.add(parser.parseMap(document.getData(), document.getId()));
+                        }
+                        taskManager.setSuccess(models);
+                    } else {
+                        taskManager.setFailure(task.getException());
+                    }
+                });
+        return taskManager.getTask();
+    }
+
+    /**
      * Get all habits that the current user needs to do for the day
      *
      * @return load task for all user's habits they need to do

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/models/HabitModel.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/models/HabitModel.java
@@ -63,15 +63,9 @@ public class HabitModel implements IHabitModel {
     private IHabitScheduleModel schedule;
 
     /**
-     * Private constructor for creating a habit model with the given data
-     *
-     * @param id            habit id
-     * @param title         habit title string
-     * @param reason        habit reason
-     * @param startDate     habit start date
-     * @param lastCompleted habit last time completed date
-     * @param streak        habit streak score
+     * Habit associated user ID
      */
+    private String UID;
 
     /**
      * Custom HabitModel Class to make HabitModelClass serializable
@@ -80,7 +74,19 @@ public class HabitModel implements IHabitModel {
 
     }
 
-    private HabitModel(String id, String title, String reason, Date startDate, Date lastCompleted, long streak, IHabitScheduleModel schedule) {
+    /**
+     * Private constructor for creating a habit model with the given data
+     *
+     * @param id            habit id
+     * @param title         habit title string
+     * @param reason        habit reason
+     * @param startDate     habit start date
+     * @param lastCompleted habit last time completed date
+     * @param streak        habit streak score
+     * @param schedule      habit schedule
+     * @param UID           habit UID
+     */
+    private HabitModel(String id, String title, String reason, Date startDate, Date lastCompleted, long streak, IHabitScheduleModel schedule, String UID) {
         this.id = id;
         this.title = sanitizeStringFromDatabase(title, IHabitModel.MAX_TITLE_LENGTH);
         this.reason = sanitizeStringFromDatabase(reason, IHabitModel.MAX_REASON_LENGTH);
@@ -88,6 +94,7 @@ public class HabitModel implements IHabitModel {
         this.lastCompleted = lastCompleted;
         this.schedule = schedule;
         this.streak = streak;
+        this.UID = UID;
     }
 
     /**
@@ -98,7 +105,7 @@ public class HabitModel implements IHabitModel {
     public static ServiceTask<HabitModel> getNewInstance() {
         HabitScheduleModelFactory scheduleFactory = new HabitScheduleModelFactory();
         ServiceTaskManager<HabitModel> taskman = new ServiceTaskManager<>();
-        taskman.setSuccess(new HabitModel(null, null, null, new Date(), null, 0, scheduleFactory.getNewModelInstance()));
+        taskman.setSuccess(new HabitModel(null, null, null, new Date(), null, 0, scheduleFactory.getNewModelInstance(), null));
         return taskman.getTask();
     }
 
@@ -306,6 +313,11 @@ public class HabitModel implements IHabitModel {
     }
 
     @Override
+    public String getUID() {
+        return this.UID;
+    }
+
+    @Override
     public IHabitScheduleModel getSchedule() {
         return this.schedule;
     }
@@ -403,7 +415,8 @@ public class HabitModel implements IHabitModel {
                     DocumentModelSerializer.parseAsDate(map.get("start_date")),
                     DocumentModelSerializer.parseAsDate(map.get("last_completed")),
                     map.get("streak") != null ? (Long) map.get("streak") : 0,
-                    scheduleFactory.getModelInstanceFromData((List<String>) map.get("schedule"))
+                    scheduleFactory.getModelInstanceFromData((List<String>) map.get("schedule")),
+                    (String) map.get("uid")
             );
         }
 

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/models/IHabitModel.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/models/IHabitModel.java
@@ -65,4 +65,11 @@ public interface IHabitModel {
      */
     IHabitScheduleModel getSchedule();
 
+    /**
+     * Get the UID associated with the habit
+     *
+     * @return User ID associated with the habit
+     */
+    String getUID();
+
 }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/AnotherUserProfileActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/AnotherUserProfileActivity.java
@@ -133,7 +133,7 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
                     changeDisplayToRequestedState();
                 } else if ((valueOfAnotherUserInCurrentUserSocialMap == 1 || valueOfAnotherUserInCurrentUserSocialMap == 2) && (isNull(valueOfCurrentUserInAnotherUserSocialMap) || valueOfCurrentUserInAnotherUserSocialMap == 0 || valueOfCurrentUserInAnotherUserSocialMap == 1 || valueOfCurrentUserInAnotherUserSocialMap == 2)) {
                     // Following screen is shown
-                    changeDisplayToFollowingState();
+                    changeDisplayToFollowingState(anotherUserID);
                 }
             });
         });
@@ -142,7 +142,7 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
     /**
      * Change the display to the Following state
      */
-    private void changeDisplayToFollowingState() {
+    private void changeDisplayToFollowingState(String anotherUserID) {
         // Set the views accordingly
         followBtn.setVisibility(View.INVISIBLE);
         followingLabel.setVisibility(View.VISIBLE);
@@ -156,7 +156,7 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
         habitList.setAdapter(habitAdapter);
 
         // Display all the habits of another user
-        HabitModel.getAllForCurrentUser().addTaskCompleteListener(task -> {
+        HabitModel.getAllForAnotherUser(anotherUserID).addTaskCompleteListener(task -> {
             habitDataList.clear();
             if (task.isSuccessful()) {
                 habitDataList.addAll(task.getResult());

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/lists/UserCustomList.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/lists/UserCustomList.java
@@ -55,10 +55,10 @@ public class UserCustomList extends ArrayAdapter<UserModel> {
         name.setText(user.getFirstName() + " " + user.getLastName());
         userName.setText(user.getUsername());
 
-        // Brings the user to the habit details screen
+        // Brings the user to the profile screen
         ShapeableImageView habitBackground = view.findViewById(R.id.user_lists_background);
         habitBackground.setOnClickListener(v -> {
-            // pass habit id to view the habit details for targeted habit
+            // Pass the UserID through intent
             Intent intent = new Intent(context, AnotherUserProfileActivity.class);
             intent.putExtra("USER_ID", user.getUID());
             context.startActivity(intent);

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/lists/UserCustomList.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/lists/UserCustomList.java
@@ -1,6 +1,7 @@
 package com.cmput301f21t09.budgetprojectname.views.lists;
 
 import android.content.Context;
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +14,9 @@ import androidx.annotation.Nullable;
 
 import com.cmput301f21t09.budgetprojectname.R;
 import com.cmput301f21t09.budgetprojectname.models.UserModel;
+import com.cmput301f21t09.budgetprojectname.views.activities.AnotherUserProfileActivity;
+import com.cmput301f21t09.budgetprojectname.views.activities.ViewHabitActivity;
+import com.google.android.material.imageview.ShapeableImageView;
 
 import java.util.ArrayList;
 
@@ -51,11 +55,13 @@ public class UserCustomList extends ArrayAdapter<UserModel> {
         name.setText(user.getFirstName() + " " + user.getLastName());
         userName.setText(user.getUsername());
 
-        Button follow = view.findViewById(R.id.follow);
-        // if user following this user
-        // set follow button to gone or unfollow
-        follow.setOnClickListener(v -> {
-            // TODO: Request follow selected user
+        // Brings the user to the habit details screen
+        ShapeableImageView habitBackground = view.findViewById(R.id.user_lists_background);
+        habitBackground.setOnClickListener(v -> {
+            // pass habit id to view the habit details for targeted habit
+            Intent intent = new Intent(context, AnotherUserProfileActivity.class);
+            intent.putExtra("USER_ID", user.getUID());
+            context.startActivity(intent);
         });
 
         return view;

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/lists/UserHabitCustomList.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/lists/UserHabitCustomList.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 
 import com.cmput301f21t09.budgetprojectname.R;
 import com.cmput301f21t09.budgetprojectname.models.HabitModel;
+import com.cmput301f21t09.budgetprojectname.services.AuthorizationService;
 import com.cmput301f21t09.budgetprojectname.views.activities.ViewHabitActivity;
 import com.google.android.material.imageview.ShapeableImageView;
 
@@ -57,15 +58,18 @@ public class UserHabitCustomList extends ArrayAdapter<HabitModel> {
         habitDescription.setText(habit.getReason());
         streak.setText(String.valueOf(habit.getStreak()));
 
-        // Brings the user to the habit details screen
-        ShapeableImageView habitBackground = view.findViewById(R.id.habit_lists_background);
-        habitBackground.setOnClickListener(v -> {
-            // pass habit id to view the habit details for targeted habit
-            Intent intent = new Intent(context, ViewHabitActivity.class);
-            intent.putExtra("HABIT_ID", habit.getId());
-            context.startActivity(intent);
-        });
+        // If this habit belongs to the currently logged-in user, set a listener to the habit
+        // such that when it is clicked, it'll bring the user to the habit details screen
+        if (habit.getUID().equals(AuthorizationService.getInstance().getCurrentUserId())) {
+            ShapeableImageView habitBackground = view.findViewById(R.id.habit_lists_background);
 
+            habitBackground.setOnClickListener(v -> {
+                // Pass habit id to view the habit details for targeted habit
+                Intent intent = new Intent(context, ViewHabitActivity.class);
+                intent.putExtra("HABIT_ID", habit.getId());
+                context.startActivity(intent);
+            });
+        }
         return view;
     }
 }

--- a/src/app/src/main/res/layout/user_custom_list.xml
+++ b/src/app/src/main/res/layout/user_custom_list.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content">
 
     <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/habit_details_background"
+        android:id="@+id/user_lists_background"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@color/white"
@@ -34,9 +34,9 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="14dp"
         android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="@+id/habit_details_background"
+        app:layout_constraintBottom_toBottomOf="@+id/user_lists_background"
         app:layout_constraintStart_toEndOf="@+id/profile_pic"
-        app:layout_constraintTop_toTopOf="@+id/habit_details_background">
+        app:layout_constraintTop_toTopOf="@+id/user_lists_background">
 
         <TextView
             android:id="@+id/name"
@@ -53,23 +53,11 @@
             android:text="\@username"
             android:textColor="#A6A6A6"
             android:textSize="11sp"
-            app:layout_constraintBottom_toBottomOf="@+id/habit_details_background"
+            app:layout_constraintBottom_toBottomOf="@+id/user_lists_background"
             app:layout_constraintStart_toEndOf="@+id/profile_pic"
-            app:layout_constraintTop_toTopOf="@+id/habit_details_background" />
+            app:layout_constraintTop_toTopOf="@+id/user_lists_background" />
 
     </LinearLayout>
-
-    <Button
-        android:id="@+id/follow"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="20dp"
-        android:backgroundTint="@color/secondary_light"
-        android:text="Follow"
-        android:textColor="@color/secondary_dark"
-        app:layout_constraintBottom_toBottomOf="@id/habit_details_background"
-        app:layout_constraintEnd_toEndOf="@id/habit_details_background"
-        app:layout_constraintTop_toTopOf="@id/habit_details_background" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
Linked the `AnotherUserProfileActivity.java` with the search fragment.

Made a change to the HabitModel so that we can access the userID of a habit in our app. This change was made so that in the `AnotherUserProfileActivity.java` screen, the logged-in user can only view the habits but not click on their friend's habits. (An if-statement is used to check if a habit is owned by the logged-in user before setting the onClick listener)

Added a function in the HabitModel so that we are able to fetch all the habits our friends own in `AnotherUserProfileActivity.java`

Removed the Follow button in the search fragment.

<!-- Provide a list of changes here -->

## Screenshots

<!-- Prefer an animated gif -->
Scenario: Request to follow a user:
1. I haven't sent a follow request to June:
![Screen Shot 2021-11-25 at 8 00 13 PM](https://user-images.githubusercontent.com/37930535/143520364-409fec6e-a470-47dc-a553-1016dde05e0d.png)

2. I'm sending a follow request to June
![Request](https://user-images.githubusercontent.com/37930535/143520041-f9ed1b31-5db2-435a-b41d-5dd8b218bb06.gif)

3. My userID is now in June's Social Map (value 0 denotes that I've sent him a follow request)
![Screen Shot 2021-11-25 at 8 00 29 PM](https://user-images.githubusercontent.com/37930535/143520427-1a9c11ee-e52e-4b9e-96e2-915ad24aaeb7.png)


Scenario: We are already following this user: (We'll be able to see this user's habits – will only be public habits down the line)
![Following](https://user-images.githubusercontent.com/37930535/143520081-1f3f88dd-3c11-4ebc-a3e6-48fc51da661f.gif)
## Checklist

- [ ] Automated tests
- [x] Screenshots included (if necessary)
- [x] Code is well commented

Closes #ISSUE_ID
