### PR TITLE
Fix nullptr error when clicking on habitEvent after editing a habitEvent

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/DefineHabitEventActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/DefineHabitEventActivity.java
@@ -80,6 +80,7 @@ public class DefineHabitEventActivity extends AppCompatActivity implements OnMap
     private String habitID;
     private String habitEventID;
     private String habitName;
+    private String habitUserID;
 
     private SupportMapFragment mapFragment;
     private SwitchMaterial locationSwitch;
@@ -104,6 +105,7 @@ public class DefineHabitEventActivity extends AppCompatActivity implements OnMap
         habitEventID = intent.getStringExtra("HABIT_EVENT_ID");
         habitID = intent.getStringExtra("HABIT_ID");
         habitName = intent.getStringExtra("HABIT_NAME");
+        habitUserID = intent.getStringExtra("HABIT_USERID");
         System.out.println("*****habitID " + habitID);
         System.out.println("****HE id" + habitEventID);
 
@@ -315,6 +317,7 @@ public class DefineHabitEventActivity extends AppCompatActivity implements OnMap
                 // return back to habit detail page
                 Intent i = new Intent(getApplicationContext(), ViewHabitActivity.class);
                 i.putExtra("HABIT_ID", habitID);
+                i.putExtra("HABIT_USERID", habitUserID);
                 i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(i);
             }

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/ViewHabitEventActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/ViewHabitEventActivity.java
@@ -123,6 +123,7 @@ public class ViewHabitEventActivity extends AppCompatActivity {
                 final String HABIT_ID = "HABIT_ID";
                 editIntent.putExtra(HABIT_ID, habitID);
                 editIntent.putExtra("HABIT_NAME", habitTitleStr);
+                editIntent.putExtra("HABIT_USERID", habitEventUID);
                 System.out.println("habit id " + habitID);
                 editIntent.putExtra(HABIT_EVENT_ID, habitEventID);
                 startActivity(editIntent);


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
There will be a nullptr error if a user clicks to view a habit Event after editing a habit event because the `habitUID` wasn't passed in. This minor change would fix this issue by passing in the `habitUID` through intent. 
<!-- Provide a list of changes here -->

## Screenshots

<!-- Prefer an animated gif -->

## Checklist

- [ ] Automated tests
- [ ] Screenshots included (if necessary)
- [ ] Code is well commented

Closes #ISSUE_ID
