### PR TITLE
Fix Request to follow ->Update social map bug

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/AnotherUserProfileActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/AnotherUserProfileActivity.java
@@ -198,7 +198,6 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
         followBtn.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 // Update the value of the currentUserId in anotherUserID's document
-//                HashMap<String, Integer> incomingFollowRequest = new HashMap<String, Integer>();
                 socialMap.put(currentUserId, newValue);
                 userController.updateUserSocialMap(anotherUserID, socialMap);
 

--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/AnotherUserProfileActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/AnotherUserProfileActivity.java
@@ -131,7 +131,7 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
                     // (Additionally, user on screen is not following the logged-in user)
                     // If the user clicks on the Follow button,
                     // increase the user on screen's Social Map's value of current user from None to 0
-                    requestToFollow(currentUserId, anotherUserID, 0);
+                    requestToFollow(currentUserId, anotherUserID, retrievedAnotherUser.getSocial(), 0);
                 } else if ((isNull(valueOfAnotherUserInCurrentUserSocialMap)
                         || valueOfAnotherUserInCurrentUserSocialMap == 0)
                         && valueOfCurrentUserInAnotherUserSocialMap == 1) {
@@ -140,7 +140,7 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
 
                     // If the user clicks on the Follow button,
                     // increase the user on screen's Social Map's value of current user from 1 to 2
-                    requestToFollow(currentUserId, anotherUserID, 2);
+                    requestToFollow(currentUserId, anotherUserID, retrievedAnotherUser.getSocial(), 2);
                 } else if ((isNull(valueOfAnotherUserInCurrentUserSocialMap)
                         || valueOfAnotherUserInCurrentUserSocialMap == 0)
                         && (valueOfCurrentUserInAnotherUserSocialMap == 0
@@ -193,13 +193,14 @@ public class AnotherUserProfileActivity extends AppCompatActivity {
      * @param anotherUserID ID of the user that that the current user wants to follow
      * @param newValue      new value to be used
      */
-    private void requestToFollow(String currentUserId, String anotherUserID, Integer newValue) {
+    private void requestToFollow(String currentUserId, String anotherUserID,
+                                 HashMap<String, Integer> socialMap, Integer newValue) {
         followBtn.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 // Update the value of the currentUserId in anotherUserID's document
-                HashMap<String, Integer> incomingFollowRequest = new HashMap<String, Integer>();
-                incomingFollowRequest.put(currentUserId, newValue);
-                userController.updateUserSocialMap(anotherUserID, incomingFollowRequest);
+//                HashMap<String, Integer> incomingFollowRequest = new HashMap<String, Integer>();
+                socialMap.put(currentUserId, newValue);
+                userController.updateUserSocialMap(anotherUserID, socialMap);
 
                 // Change the display to Requested State
                 changeDisplayToRequestedState();


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
Right now, if we request to follow another user, that person's Social map will be wiped clean and will be replaced with the new key and value.

This change would address this bug by appending the new key and value to the user's existing social map before sending it to Firestore. 

<!-- Provide a list of changes here -->

## Screenshots

<!-- Prefer an animated gif -->
`testUser2`'s social map before we request to follow them:
![Screen Shot 2021-11-27 at 8 29 10 PM](https://user-images.githubusercontent.com/37930535/143727722-20d23b4c-7c8b-452a-8ea7-1ff3ae93aaf8.png)

Sending a follow request to `testUser2`
![fix-another-user-profile-firestore-bug](https://user-images.githubusercontent.com/37930535/143727774-7b1c97c7-45a7-450d-8a39-17a73d4e068f.gif)

`testUser2`'s social map after we've requested to follow them(The existing key and value that they have is still intact):
![Screen Shot 2021-11-27 at 8 32 00 PM](https://user-images.githubusercontent.com/37930535/143727845-936e941d-aaa4-4cb4-add2-c0729e602b8c.png)

## Checklist

- [ ] Automated tests
- [x] Screenshots included (if necessary)
- [x] Code is well commented

Closes #ISSUE_ID
