### PR TITLE
Unit test user controller + Improve user search functionality

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/fragments/SearchFragment.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/fragments/SearchFragment.java
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment;
 import com.cmput301f21t09.budgetprojectname.R;
 import com.cmput301f21t09.budgetprojectname.controllers.UserController;
 import com.cmput301f21t09.budgetprojectname.models.UserModel;
+import com.cmput301f21t09.budgetprojectname.services.AuthorizationService;
 import com.cmput301f21t09.budgetprojectname.views.lists.UserCustomList;
 
 import java.util.ArrayList;
@@ -97,7 +98,7 @@ public class SearchFragment extends Fragment {
         final int currentRequest = ++this.request;
 
         new UserController().readUserByUserName(keyword, user -> {
-            if (currentRequest == this.request && user != null) {
+            if (currentRequest == this.request && user != null && !user.getUID().equals(AuthorizationService.getInstance().getCurrentUserId())) {
                 users.add(user);
                 users.sort(Comparator.comparing(UserModel::getFirstName));
                 userList.notifyDataSetChanged();

--- a/src/app/src/test/java/com/cmput301f21t09/budgetprojectname/UserControllerTest.java
+++ b/src/app/src/test/java/com/cmput301f21t09/budgetprojectname/UserControllerTest.java
@@ -1,0 +1,112 @@
+package com.cmput301f21t09.budgetprojectname;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.cmput301f21t09.budgetprojectname.models.UserModel;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Tests for database operations on users mocked using arraylists
+ */
+public class UserControllerTest {
+    /**
+     * Tests reading of user
+     */
+    @Test
+    public void testReadUser() {
+        ArrayList<UserModel> userList = new ArrayList<>();
+        UserModel user =
+                new UserModel("XPG70micV5XLyvhytqghBOLnK8U2", "testUser1",
+                        "Test", "User", new HashMap<>());
+        userList.add(user);
+
+        UserModel readUser = userList.get(0);
+        assertEquals("XPG70micV5XLyvhytqghBOLnK8U2", readUser.getUID());
+        assertEquals("testUser1", readUser.getUsername());
+    }
+
+    /**
+     * Test reading a user by username
+     */
+    @Test
+    public void testReadUserByUserName() {
+        ArrayList<UserModel> userList = new ArrayList<>();
+        UserModel user =
+                new UserModel("XPG70micV5XLyvhytqghBOLnK8U2", "testUser1",
+                        "Test", "User", new HashMap<>());
+        userList.add(user);
+
+        UserModel readUser = null;
+
+        // Find the user by username
+        for (UserModel targetUser : userList) {
+            if (targetUser.equals(user)) {
+                readUser = targetUser;
+            }
+        }
+
+        assertEquals("XPG70micV5XLyvhytqghBOLnK8U2", readUser.getUID());
+        assertEquals("testUser1", readUser.getUsername());
+    }
+
+    /**
+     * Test reading a user's follow requests and users that they follow
+     */
+    @Test
+    public void testReadFollows() {
+        ArrayList<UserModel> userList = new ArrayList<>();
+        UserModel user =
+                new UserModel("XPG70micV5XLyvhytqghBOLnK8U2", "testUser1",
+                        "Test", "User", new HashMap<>());
+
+        HashMap<String, Integer> followRequests = new HashMap<>();
+        followRequests.put("BtVfJ5exBBgpYXchbR4wsN8f0cp1", 0);
+        user.setSocial(followRequests);
+
+        userList.add(user);
+
+        // Check the follow request
+        HashMap<String, Integer> readFollowRequests = userList.get(0).getSocial();
+        assertTrue(readFollowRequests.get("BtVfJ5exBBgpYXchbR4wsN8f0cp1").equals(0)
+                || readFollowRequests.get("BtVfJ5exBBgpYXchbR4wsN8f0cp1").equals(2));
+
+        HashMap<String, Integer> followingUsers = new HashMap<>();
+        followRequests.put("ZfOzqcG2GHVoWe14WOXOMdpY4DA2", 1);
+        user.setSocial(followingUsers);
+
+        userList.add(user);
+
+        // Check users that we follow
+        HashMap<String, Integer> readFollowingUsers = userList.get(1).getSocial();
+        assertTrue(readFollowRequests.get("ZfOzqcG2GHVoWe14WOXOMdpY4DA2").equals(1)
+                || readFollowRequests.get("ZfOzqcG2GHVoWe14WOXOMdpY4DA2").equals(2));
+    }
+
+    /**
+     * Test updating a user's Social Map
+     */
+    @Test
+    public void testUpdateUserSocialMap() {
+        ArrayList<UserModel> userList = new ArrayList<>();
+        UserModel user =
+                new UserModel("XPG70micV5XLyvhytqghBOLnK8U2", "testUser1",
+                        "Test", "User", new HashMap<>());
+        userList.add(user);
+        UserModel toUpdateUser = userList.get(0);
+        userList.remove(0); // The actual DB will not remove the document
+
+        HashMap<String, Integer> newSocialMap = new HashMap<>();
+        newSocialMap.put("BtVfJ5exBBgpYXchbR4wsN8f0cp1", 1);
+        toUpdateUser.setSocial(newSocialMap);
+
+        userList.add(toUpdateUser);
+
+        assertEquals(1, userList.size());
+        assertEquals(newSocialMap, userList.get(0).getSocial());
+    }
+}


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
Wrote unit tests for `UserController.java`

Improved the search user functionality by preventing a user from searching up himself/herself, thus preventing them from sending a follow request to their own account. 

<!-- Provide a list of changes here -->
## Screenshots
![Screen Shot 2021-11-28 at 3 43 40 PM](https://user-images.githubusercontent.com/37930535/143789245-bec41415-3c28-499a-aaa3-fc320100e307.png)
<!-- Prefer an animated gif -->

I'm signed-in as `tey`, hence `tey` wouldn't show up when I search up users (only `tey2`showed up):

https://user-images.githubusercontent.com/37930535/143789375-f10898b4-1ab4-4596-9703-e1ac28d65ba4.mov



## Checklist

- [x] Automated tests
- [x] Screenshots included (if necessary)
- [x] Code is well commented

Closes #265 
