### PR TITLE
fix missing space in date on habit event page

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/ViewHabitEventActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/ViewHabitEventActivity.java
@@ -110,7 +110,7 @@ public class ViewHabitEventActivity extends AppCompatActivity {
 
             habitEventDescription.setText(retrievedHabitEvent.getComment());
 
-            SimpleDateFormat format = new SimpleDateFormat("MMMM dd,yyyy");
+            SimpleDateFormat format = new SimpleDateFormat("MMMM dd, yyyy");
             String strDate = format.format(retrievedHabitEvent.getDate());
             habitEventDate.setText(strDate);
 


### PR DESCRIPTION
Fixed missing space in date on habit event page

## Screenshots

![image](https://user-images.githubusercontent.com/53621618/143794637-48ce97d2-4a6d-4215-a782-cfa04ecdf5e3.png)

## Checklist

- [ ] Automated tests
- [ ] Screenshots included (if necessary)
- [ ] Code is well commented
