### PR TITLE
Fix a bug in View Habit Details and View Habit Event Screen

### DIFF
--- a/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/ViewHabitEventActivity.java
+++ b/src/app/src/main/java/com/cmput301f21t09/budgetprojectname/views/activities/ViewHabitEventActivity.java
@@ -150,6 +150,7 @@ public class ViewHabitEventActivity extends AppCompatActivity {
                 Intent deleteIntent = new Intent(getApplicationContext(), ViewHabitActivity.class);
                 final String HABIT_ID = "HABIT_ID";
                 deleteIntent.putExtra(HABIT_ID, habitID);
+                deleteIntent.putExtra("HABIT_USERID", habitEventUID);
                 deleteIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(deleteIntent);
             });


### PR DESCRIPTION
<!-- Description of PR -->

## Description of Changes
Right now, the app would crash when we delete a habit event and then try to view another habit event of the same habit.

This change would address this issue.
<!-- Provide a list of changes here -->

## Screenshots

<!-- Prefer an animated gif -->
https://user-images.githubusercontent.com/37930535/143804160-56c956ab-c08f-44af-bdfa-2efc47bcd3b7.mov
## Checklist


- [ ] Automated tests
- [x] Screenshots included (if necessary)
- [] Code is well commented

Closes #ISSUE_ID
